### PR TITLE
fix: include resolved world seed in the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - The page opens on a white veil, then stands still behind one **Begin** button; nothing moves and no sound plays until you press it. Sound is synthesized in the browser, with an on/off switch and a volume slider that starts at half.
 - Do nothing and the bird flies itself. Drag with the left button to orbit the bird, and the view stays where you leave it; drag with the right button to steer, up and down as well, and the bird flies where you look. The wheel zooms, touch steers, and the arrow keys nudge a turn or a climb that fades after a few seconds.
 - **Pause**, or space with the canvas focused, stops the flight and the sound together. A reduced-motion preference starts the page paused.
-- The page remembers your sound settings, your framing, and the bird's exact place, course and time of day, and resumes there after Begin. `?seed=<number>` in the address opens that world fresh; the page writes that seed into the address so a copied URL is the same world, and the share link carries it.
+- The page remembers your sound settings, your framing, and the bird's exact place, course and time of day, and resumes there after Begin. `?seed=<number>` in the address opens that world fresh. The resolved seed is always written into the address so a copied URL opens the same world, and the share link carries it.
 - WebGPU is used when available, over HTTPS or localhost; `?webgl=1` forces WebGL2, and the desktop corner names the backend.
 
 ## Read on

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - The page opens on a white veil, then stands still behind one **Begin** button; nothing moves and no sound plays until you press it. Sound is synthesized in the browser, with an on/off switch and a volume slider that starts at half.
 - Do nothing and the bird flies itself. Drag with the left button to orbit the bird, and the view stays where you leave it; drag with the right button to steer, up and down as well, and the bird flies where you look. The wheel zooms, touch steers, and the arrow keys nudge a turn or a climb that fades after a few seconds.
 - **Pause**, or space with the canvas focused, stops the flight and the sound together. A reduced-motion preference starts the page paused.
-- The page remembers your sound settings, your framing, and the bird's exact place, course and time of day, and resumes there after Begin. `?seed=<number>` in the address opens that world fresh; the share link carries the seed.
+- The page remembers your sound settings, your framing, and the bird's exact place, course and time of day, and resumes there after Begin. `?seed=<number>` in the address opens that world fresh; the page writes that seed into the address so a copied URL is the same world, and the share link carries it.
 - WebGPU is used when available, over HTTPS or localhost; `?webgl=1` forces WebGL2, and the desktop corner names the backend.
 
 ## Read on

--- a/src/main.js
+++ b/src/main.js
@@ -146,6 +146,7 @@ const storedFlight = remember.read(RESUME_KEY);
 // ---------------------------------------------------------------------------
 // Seed. ?seed=<number> reproduces a world and always wins; without one the
 // remembered world continues, and with nothing remembered every visit is new.
+// The address always carries the resolved seed so a copied URL is that world.
 // ---------------------------------------------------------------------------
 const params = new URLSearchParams(location.search);
 // `?profile=1` arms the renderer's timestamp queries and the raw frame trace
@@ -162,9 +163,9 @@ if (!Number.isFinite(seed))
   seed = finite(storedFlight?.seed, 0, 0xffffffff) ?? (Math.random() * 0xffffffff) >>> 0;
 seed = seed >>> 0;
 const shareUrl = new URL(location.href);
-shareUrl.search = '';
 shareUrl.searchParams.set('seed', String(seed));
 document.getElementById('shareLink').href = shareUrl.toString();
+history.replaceState(null, '', shareUrl);
 
 // ---------------------------------------------------------------------------
 // The look: palette anchors through the whole day, keyed in solar phase (0.25

--- a/src/main.js
+++ b/src/main.js
@@ -162,10 +162,13 @@ let seed = parseInt(params.get('seed'), 10);
 if (!Number.isFinite(seed))
   seed = finite(storedFlight?.seed, 0, 0xffffffff) ?? (Math.random() * 0xffffffff) >>> 0;
 seed = seed >>> 0;
-const shareUrl = new URL(location.href);
+const addressUrl = new URL(location.href);
+addressUrl.searchParams.set('seed', String(seed));
+history.replaceState(null, '', addressUrl);
+const shareUrl = new URL(addressUrl);
+shareUrl.search = '';
 shareUrl.searchParams.set('seed', String(seed));
 document.getElementById('shareLink').href = shareUrl.toString();
-history.replaceState(null, '', shareUrl);
 
 // ---------------------------------------------------------------------------
 // The look: palette anchors through the whole day, keyed in solar phase (0.25

--- a/tests/flight-checks.js
+++ b/tests/flight-checks.js
@@ -49,6 +49,10 @@ async function flightChecks() {
   const { win, doc, z } = world;
   const button = (id) => doc.getElementById(id).click();
   assert(z && !win.flightFailed, 'scene initialized');
+  assert(
+    new URL(win.location.href).searchParams.get('seed') === String(z.seed),
+    'the address carries the resolved seed',
+  );
   assert(z.ready && doc.getElementById('loading').classList.contains('gone'), 'the veil held until the first frame was drawn, then lifted');
   const gate = doc.getElementById('begin');
   assert(
@@ -1050,6 +1054,11 @@ async function flightChecks() {
   noSeed.searchParams.delete('seed');
   const again = await openWorld(noSeed.href);
   assert(again.z.seed === left.seed && again.z.resumed, 'reopening without a seed continues the remembered world');
+  const againUrl = new URL(again.win.location.href);
+  assert(againUrl.searchParams.get('seed') === String(left.seed), 'a seedless load writes the resolved seed into the address');
+  for (const [key, value] of noSeed.searchParams) {
+    assert(againUrl.searchParams.get(key) === value, 'writing the seed leaves the rest of the query intact');
+  }
   assert(!again.z.intro.beat && again.z.intro.ended === null, 'a remembered flight resumes without the opening');
   assert(
     ['x', 'y', 'z', 'heading', 't'].every((k) => Math.abs(again.z.state[k] - left[k]) < 0.000001) &&
@@ -1084,6 +1093,10 @@ async function flightChecks() {
   assert(
     fresh.z.seed === (left.seed + 1) >>> 0 && !fresh.z.resumed && fresh.z.state.t === 0,
     'a seed in the address opens that world from its start',
+  );
+  assert(
+    new URL(fresh.win.location.href).searchParams.get('seed') === String((left.seed + 1) >>> 0),
+    'an explicit seed stays in the address as given',
   );
   assert(fresh.z.volume === 0.4 && fresh.z.muted, 'settings carry over to another world');
   assert(fresh.z.intro.beat === 'side', 'another world opens with the opening again');

--- a/tests/flight-checks.js
+++ b/tests/flight-checks.js
@@ -1059,6 +1059,10 @@ async function flightChecks() {
   for (const [key, value] of noSeed.searchParams) {
     assert(againUrl.searchParams.get(key) === value, 'writing the seed leaves the rest of the query intact');
   }
+  assert(
+    new URL(again.doc.getElementById('shareLink').href).search === `?seed=${left.seed}`,
+    'the share link carries only the resolved seed',
+  );
   assert(!again.z.intro.beat && again.z.intro.ended === null, 'a remembered flight resumes without the opening');
   assert(
     ['x', 'y', 'z', 'heading', 't'].every((k) => Math.abs(again.z.state[k] - left[k]) < 0.000001) &&


### PR DESCRIPTION
## Intent

Bug: visiting the live site at https://kunchenguid.github.io/fly-with-me/ (no `?seed=`) picks a world but does NOT put the seed into the address-bar URL. So if someone copies the URL to share, the recipient gets a DIFFERENT world instead of the same one. The captain wants the resolved seed always reflected in the visible/copyable URL so links reproduce the same world.

## What Changed

- Write the resolved world seed into the visible URL while preserving other query parameters.
- Keep share links limited to the resolved seed for reproducible worlds.
- Document and test URL behavior for generated, remembered, and explicit seeds.

## Risk Assessment

✅ Low: The change is narrowly scoped, preserves existing query parameters in the visible URL, keeps shared links seed-only, and correctly normalizes the resolved seed before updating both URLs.

## Testing

Reviewed the target diff, served the source product locally, and drove targeted Chrome scenarios for seedless, copied, explicit, and invalid seed URLs. The running world loaded successfully, the resolved seed appeared in the browser location, copied links reproduced the same world, auxiliary address parameters remained intact, and share links contained only the seed. A rendered-world screenshot and live URL-state logs were captured. No broad test suite, lint, formatter, or static analysis was run.

- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A visitor opens the site without a seed and the chosen world seed appears in the visible URL | ✅ pass | live | The seedless-address.log records a ready running product with resolved seed 3821844631 and visible address containing seed=3821844631; seedless-world-gate-final.png shows the rendered world. |
| A recipient opens the copied seed-only link and receives the same world | ✅ pass | live | copied-link-recipient.log records recipientSeed 3821844631 matching expectedCopiedSeed 3821844631 with sameWorld=true. |
| Address-only development parameters remain visible but are not leaked through the share link | ✅ pass | live | seedless-address.log records profile=1 and check=evidence-seedless retained in the visible address while shareQueryKeys contains only seed. |
| An invalid seed is replaced by the numeric resolved seed instead of remaining unshareable | ✅ pass | live | invalid-seed-address.log records the invalid input replaced by numeric seed 3354728877 in both the running world and visible address, with a seed-only share link. |

![Rendered world reached from a seedless visit](https://github.com/user-attachments/assets/6985c762-395b-4f72-b1c1-a32cfded2cfc)
- Evidence: [Rendered world reached from a seedless visit](https://github.com/kunchenguid/fly-with-me/blob/6573160ecb1d97f3afea096eaee0b7155c2121c2/.no-mistakes/evidence/fm/fly-with-me-seed-url-param-r1/seedless-world-gate-final.png)
<details>
<summary>Evidence: Seedless visit visible-address and share-link state</summary>

Source: [Seedless visit visible-address and share-link state](https://github.com/kunchenguid/fly-with-me/blob/6573160ecb1d97f3afea096eaee0b7155c2121c2/.no-mistakes/evidence/fm/fly-with-me-seed-url-param-r1/seedless-address.log)

```text
Scenario: seedless visit resolves a seed into the visible address and seed-only share link
result: "{\"runningProductReady\":true,\"flightFailed\":false,\"resolvedSeed\":3821844631,\"visibleAddress\":\"http://127.0.0.1:8123/index.html?profile=1&check=evidence-seedless&seed=3821844631\",\"visibleSeed\":\"3821844631\",\"retainedParams\":{\"profile\":\"1\",\"check\":\"evidence-seedless\"},\"shareLink\":\"http://127.0.0.1:8123/index.html?seed=3821844631\",\"shareQueryKeys\":[\"seed\"]}"
help[1]:
  Run `chrome-devtools-axi snapshot` to see current page state
```
</details>
<details>
<summary>Evidence: Copied-link recipient receives the same world</summary>

Source: [Copied-link recipient receives the same world](https://github.com/kunchenguid/fly-with-me/blob/6573160ecb1d97f3afea096eaee0b7155c2121c2/.no-mistakes/evidence/fm/fly-with-me-seed-url-param-r1/copied-link-recipient.log)

```text
Scenario: recipient opens the copied seed-only link and gets the same resolved world
result: "{\"runningProductReady\":true,\"flightFailed\":false,\"recipientAddress\":\"http://127.0.0.1:8123/index.html?seed=3821844631\",\"recipientSeed\":3821844631,\"expectedCopiedSeed\":3821844631,\"sameWorld\":true}"
help[1]:
  Run `chrome-devtools-axi snapshot` to see current page state
```
</details>
<details>
<summary>Evidence: Invalid seed resolution and query isolation</summary>

Source: [Invalid seed resolution and query isolation](https://github.com/kunchenguid/fly-with-me/blob/6573160ecb1d97f3afea096eaee0b7155c2121c2/.no-mistakes/evidence/fm/fly-with-me-seed-url-param-r1/invalid-seed-address.log)

```text
Scenario: invalid seed resolves to numeric visible URL while retaining address parameters and keeping share link seed-only
result: "{\"runningProductReady\":true,\"flightFailed\":false,\"resolvedSeed\":3354728877,\"visibleAddress\":\"http://127.0.0.1:8123/index.html?seed=3354728877&profile=1&check=invalid-live\",\"visibleSeed\":\"3354728877\",\"retainedParams\":{\"profile\":\"1\",\"check\":\"invalid-live\"},\"shareLink\":\"http://127.0.0.1:8123/index.html?seed=3354728877\",\"shareQueryKeys\":[\"seed\"]}"
help[1]:
  Run `chrome-devtools-axi snapshot` to see current page state
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"41c208e2dc818d906b03ad64bcc852a4b1cdb4c4","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/main.js:167` - The share link now retains every query parameter because the prior query reset was removed. For example, visiting with `?profile=1&amp;check=...` shares profiling and cache-busting options, although the intent only requires adding the resolved seed to the visible URL. Keep the full query for `history.replaceState`, but retain a seed-only URL for `#shareLink` unless this expanded sharing behavior is intentional.

🔧 Fix applied.
✅ Re-checked - no issues remain.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- Live validation: ✅ go - 4 of 4 scenarios driven live against the product

| Scenario | Result | Live | Evidence |
| --- | --- | --- | --- |
| A visitor opens the site without a seed and the chosen world seed appears in the visible URL | ✅ pass | live | The seedless-address.log records a ready running product with resolved seed 3821844631 and visible address containing seed=3821844631; seedless-world-gate-final.png shows the rendered world. |
| A recipient opens the copied seed-only link and receives the same world | ✅ pass | live | copied-link-recipient.log records recipientSeed 3821844631 matching expectedCopiedSeed 3821844631 with sameWorld=true. |
| Address-only development parameters remain visible but are not leaked through the share link | ✅ pass | live | seedless-address.log records profile=1 and check=evidence-seedless retained in the visible address while shareQueryKeys contains only seed. |
| An invalid seed is replaced by the numeric resolved seed instead of remaining unshareable | ✅ pass | live | invalid-seed-address.log records the invalid input replaced by numeric seed 3354728877 in both the running world and visible address, with a seed-only share link. |

- `python3 -m http.server 8123`
- `CHROME_DEVTOOLS_AXI_SESSION=seed-url-test npx -y chrome-devtools-axi open 'http://127.0.0.1:8123/index.html?profile=1&check=evidence-seedless'`
- `CHROME_DEVTOOLS_AXI_SESSION=seed-url-test npx -y chrome-devtools-axi eval '() => ({ resolved seed, visible address, retained parameters, share link })'`
- <code>`CHROME_DEVTOOLS_AXI_SESSION=seed-url-test npx -y chrome-devtools-axi open &#39;http://127.0.0.1:8123/index.html?seed=3821844631&#39;` and compared the recipient world seed</code>
- `CHROME_DEVTOOLS_AXI_SESSION=seed-url-test npx -y chrome-devtools-axi open 'http://127.0.0.1:8123/index.html?seed=not-a-number&profile=1&check=invalid-live'`
- `CHROME_DEVTOOLS_AXI_SESSION=seed-url-test npx -y chrome-devtools-axi screenshot ~/.no-mistakes/evidence/01M21PGFGJC5FTD9VWKVDY9NRT/seedless-world-gate-final.png`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
