### PR TITLE
ci: exempt captain PRs from require-no-mistakes

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -24,7 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.user.login != 'github-actions[bot]' &&
-      github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event.pull_request.user.login != 'dependabot[bot]' &&
+      github.event.pull_request.user.login != 'kunchenguid'
     steps:
       - name: Verify no-mistakes signature and pipeline attestation
         uses: kunchenguid/no-mistakes/.github/actions/require-no-mistakes@32d396ac0f29135daf7fcb9964aba9d5f4e796d6 # post-v1.57.1, untagged (action added in #819)


### PR DESCRIPTION
## Summary
- Skip the require-no-mistakes check job for PRs authored by `kunchenguid`, matching the existing bot exemptions.
- External-contributor PRs still run the same attestation verification.
- Job-level `if:` skips report as success for required checks, so no extra always-passing fallback job is needed.

## Test plan
- Confirm this PR's require-no-mistakes check is skipped (GitHub uses the workflow from the PR head for `pull_request`).
- Confirm the check job still runs for a non-exempt author (bots remain exempt; other humans remain gated).